### PR TITLE
Migrating from master/slave words

### DIFF
--- a/flask-aws/bin/jp.py
+++ b/flask-aws/bin/jp.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 import sys
 import json

--- a/flask-aws/bin/rst2html.py
+++ b/flask-aws/bin/rst2html.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rst2html.py 4564 2006-05-21 20:44:42Z wiemann $
 # Author: David Goodger <goodger@python.org>

--- a/flask-aws/bin/rst2html5.py
+++ b/flask-aws/bin/rst2html5.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 # -*- coding: utf8 -*-
 # :Copyright: © 2015 Günter Milde.
 # :License: Released under the terms of the `2-Clause BSD license`_, in short:

--- a/flask-aws/bin/rst2latex.py
+++ b/flask-aws/bin/rst2latex.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rst2latex.py 5905 2009-04-16 12:04:49Z milde $
 # Author: David Goodger <goodger@python.org>

--- a/flask-aws/bin/rst2man.py
+++ b/flask-aws/bin/rst2man.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # Author: 
 # Contact: grubert@users.sf.net

--- a/flask-aws/bin/rst2odt.py
+++ b/flask-aws/bin/rst2odt.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rst2odt.py 5839 2009-01-07 19:09:28Z dkuhlman $
 # Author: Dave Kuhlman <dkuhlman@rexx.com>

--- a/flask-aws/bin/rst2odt_prepstyles.py
+++ b/flask-aws/bin/rst2odt_prepstyles.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rst2odt_prepstyles.py 5839 2009-01-07 19:09:28Z dkuhlman $
 # Author: Dave Kuhlman <dkuhlman@rexx.com>

--- a/flask-aws/bin/rst2pseudoxml.py
+++ b/flask-aws/bin/rst2pseudoxml.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rst2pseudoxml.py 4564 2006-05-21 20:44:42Z wiemann $
 # Author: David Goodger <goodger@python.org>

--- a/flask-aws/bin/rst2s5.py
+++ b/flask-aws/bin/rst2s5.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rst2s5.py 4564 2006-05-21 20:44:42Z wiemann $
 # Author: Chris Liechti <cliechti@gmx.net>

--- a/flask-aws/bin/rst2xetex.py
+++ b/flask-aws/bin/rst2xetex.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rst2xetex.py 7847 2015-03-17 17:30:47Z milde $
 # Author: Guenter Milde

--- a/flask-aws/bin/rst2xml.py
+++ b/flask-aws/bin/rst2xml.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rst2xml.py 4564 2006-05-21 20:44:42Z wiemann $
 # Author: David Goodger <goodger@python.org>

--- a/flask-aws/bin/rstpep2html.py
+++ b/flask-aws/bin/rstpep2html.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 # $Id: rstpep2html.py 4564 2006-05-21 20:44:42Z wiemann $
 # Author: David Goodger <goodger@python.org>

--- a/flask-aws/bin/wsdump.py
+++ b/flask-aws/bin/wsdump.py
@@ -1,4 +1,4 @@
-#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-master/flask-aws/bin/python
+#!/Users/rohanpavuluri/Desktop/flask-aws-tutorial-main/flask-aws/bin/python
 
 import argparse
 import code


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.